### PR TITLE
feat: support python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Sree enables you to easily manage your files through Amazon S3 protocol. Simply 
 ```
 > git clone https://github.com/cannium/Sree.git
 > cd Sree
-> sudo pip install flask pycurl
+> sudo pip install flask
 > python app.py
 ```
 

--- a/app.py
+++ b/app.py
@@ -16,15 +16,18 @@ import hashlib
 
 app = Flask(__name__, static_url_path='')
 
-import urlparse
+try:
+    from urlparse import urlparse, urlunparse
+except ImportError:
+    from urllib.parse import urlparse, urlunparse
 
 
 def get_url_from_req(request):
     url = from_request(request, 'url')
-    parsed = urlparse.urlparse(url)
+    parsed = urlparse(url)
     rgw_civetweb_port = app.config['RGW_CIVETWEB_PORT']
     rgw_address = "127.0.0.1:" + rgw_civetweb_port
-    return urlparse.urlunparse((parsed[0], rgw_address, parsed[2], parsed[3], parsed[4], parsed[5]))
+    return urlunparse((parsed[0], rgw_address, parsed[2], parsed[3], parsed[4], parsed[5]))
 
 
 def from_request(request, k):

--- a/app.py
+++ b/app.py
@@ -107,7 +107,7 @@ def putcors():
       <ExposeHeader>ETag</ExposeHeader>
   </CORSRule>
 </CORSConfiguration>'''
-    content_md5 = base64.b64encode(hashlib.md5(cors).digest())
+    content_md5 = base64.b64encode(hashlib.md5(cors.encode()).digest()).decode()
 
     headers = {
         'Content-type':'text/xml',

--- a/app.py
+++ b/app.py
@@ -2,14 +2,13 @@
 # encoding=utf-8
 
 import json
-from StringIO import StringIO
 
 from flask import Flask
 from flask import json
 from flask import request
 from flask import send_from_directory
 from flask import Response
-import pycurl
+import requests
 
 import xmlparser
 import base64
@@ -35,13 +34,16 @@ def from_request(request, k):
 
 
 def req(url, method):
-    c = pycurl.Curl()
-    c.setopt(pycurl.URL, url)
-    c.setopt(pycurl.CUSTOMREQUEST, method)
-    c.perform()
-    statuscode = c.getinfo(c.HTTP_CODE)
-    c.close()
-    return statuscode
+    command = requests.get
+    if method == 'DELETE':
+        command = requests.delete
+    elif method == 'PUT':
+        command = requests.put
+    elif method == 'POST':
+        command = requests.post
+    r = command(url)
+    return r.status_code
+
 
 
 @app.route("/createbucket", methods=['POST'])
@@ -103,17 +105,17 @@ def putcors():
   </CORSRule>
 </CORSConfiguration>'''
     content_md5 = base64.b64encode(hashlib.md5(cors).digest())
-    c = pycurl.Curl()
-    c.setopt(pycurl.URL, corsurl)
-    c.setopt(pycurl.HTTPHEADER, ['Content-type: text/xml',
-                                 'Content-MD5: ' + content_md5,
-                                 'Authorization: ' + s3auth,
-                                 'Date: ' + date])
-    c.setopt(pycurl.CUSTOMREQUEST, 'PUT')
-    c.setopt(pycurl.POSTFIELDS, cors)
-    c.perform()
-    statuscode = c.getinfo(c.HTTP_CODE)
-    c.close()
+
+    headers = {
+        'Content-type':'text/xml',
+        'Content-MD5':content_md5,
+        'Authorization':s3auth,
+        'Date' : date
+    }
+
+    r  = requests.put(corsurl, headers=headers, data=cors)
+    statuscode = r.status_code
+
     if statuscode == 200:
         resp = Response(status=statuscode)
     elif statuscode == 403:
@@ -129,15 +131,11 @@ def listbucketsurl():
     s3auth = from_request(request, 's3auth')
     date = from_request(request, 'date')
 
-    storage = StringIO()
-    c = pycurl.Curl()
-    c.setopt(pycurl.URL, url)
-    c.setopt(c.WRITEFUNCTION, storage.write)
-    c.setopt(pycurl.HTTPHEADER, ['Authorization: ' + s3auth,
-                                 'x-amz-date: ' + date])
-    c.perform()
-    statuscode = c.getinfo(c.HTTP_CODE)
-    c.close()
+    headers = {'Authorization':s3auth, 'x-amz-date': date}
+
+    r = requests.get(url, headers=headers)
+
+    statuscode = r.status_code
 
     if statuscode != 200:
         if statuscode == 403:
@@ -146,7 +144,8 @@ def listbucketsurl():
             resp = Response(response='Unknown Error', status=500)
         return resp
 
-    content = storage.getvalue()
+    content = r.text
+
     buckets = xmlparser.getListFromXml(content, 'Bucket')
     resp = Response(response=json.dumps(buckets), status=statuscode)
     resp.headers['Content-type'] = 'application/json; charset=UTF-8'

--- a/xmlparser.py
+++ b/xmlparser.py
@@ -45,13 +45,10 @@ def getTreeFromXml(xml):
         if xmlns:
             tree.attrib['xmlns'] = xmlns
         return tree
-    except ExpatError, e:
-        error(e)
-        raise Exceptions.ParameterError("Bucket contains invalid filenames.")
-    except Exception, e:
-        error(e)
-        error(xml)
-        raise
+    except ExpatError:
+        raise Exception("Bucket contains invalid filenames.")
+    except Exception as e:
+        raise e
 
 def getListFromXml(xml, node):
     tree = getTreeFromXml(xml)


### PR DESCRIPTION
The Sree interface wasn't compatible with python3. Thoses changes allow
to run sree on both python 2 and 3.
This was breaking ceph nano (cn) with the CentOS 8 based ceph container
images (like master/octopus).

- Remove pycurl/StringIO requirements and switch to requests [1]
- Change the exception syntax in xmlparse.py [2]
- Try to import urlparse (py2) then urllib.parse (py3)
- CORSConfiguration encode/decode for md5 content